### PR TITLE
Remove regex dependency by using string replacement

### DIFF
--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -20,7 +20,6 @@ chrono = { version = "0.4.11", features = ["serde"] }
 futures = "0.3.4"
 lazy_static = "1.4.0"
 influxdb_derive = { version = "0.4.0", optional = true }
-regex = "1.3.5"
 
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Description

The use of regex here can be removed by dropping in some simple string substitutions instead. This should be faster but more importantly lets us drop the dependency on the regex library and all its sizeable dependencies of its own.

Credit to @Freaky for modified escape_any function

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment