### PR TITLE
Remove use of HashMap

### DIFF
--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -139,12 +139,9 @@ impl Client {
         }
 
         let url = &format!("{}/query", &self.url);
-        let mut parameters = self.parameters.as_ref().clone();
-        parameters.insert("q", read_query);
         let request = self
-            .client
-            .request(reqwest::Method::GET, url)
-            .query(&parameters)
+            .build_db_request(reqwest::Method::GET, url)
+            .query(&[("q", read_query)])
             .build()
             .map_err(|err| Error::UrlConstructionError {
                 error: err.to_string(),


### PR DESCRIPTION
## Description

(attempt 2, ignore #2!)

This may be a matter of preference, but I'd like to know what you think!

Removing HashMap here should make this faster and avoids the need to clone the map and add to the clone all the time by calling query more than once (this just appends to the query).

Storing the tuples in the format that query expects to be called with means we just construct them once at build time then pass the same thing by reference forever. Should be super-quick :)

### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment